### PR TITLE
ci: fetch full git history to publish chromatic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2


### PR DESCRIPTION
In order to publish chromatic we need to fetch full git history in publish.yml workflow (the same as we do in ci.yml)