### PR TITLE
ci: allow semantic-release to push changed files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  packages: write
-  actions: read
-  pull-requests: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -25,6 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Collect Workflow Telemetry
         uses: catchpoint/workflow-telemetry-action@v2


### PR DESCRIPTION
Allow semantic release to push changed files to main branch, and remove leftovers from using `GITHUB_TOKEN`