### PR TITLE
feat: change message property type for info bar component

### DIFF
--- a/src/design-system/info-bar/info-bar.component.tsx
+++ b/src/design-system/info-bar/info-bar.component.tsx
@@ -9,7 +9,7 @@ import { Text } from '../text';
 import * as cx from './info-bar.css';
 
 export interface Props {
-  message: string;
+  message: ReactNode;
   icon: ReactNode;
   callToAction?: {
     label?: string;


### PR DESCRIPTION
Make InfoBar component accepts ReactNode instead of string