### PR TITLE
feat: add wallet onboarding icons and additional colors [LW-10641]

### DIFF
--- a/src/design-system/text/text.css.ts
+++ b/src/design-system/text/text.css.ts
@@ -45,6 +45,11 @@ export const typography = recipe({
       success: sx({ color: '$data_green' }),
       error: sx({ color: '$data_pink' }),
       warning: sx({ color: '$data_orange' }),
+      laceGradient: sx({
+        backgroundImage: '$text_gradient',
+        WebkitBackgroundClip: 'text',
+        WebkitTextFillColor: 'transparent',
+      }),
     },
   },
 });

--- a/src/design-tokens/colors.data.ts
+++ b/src/design-tokens/colors.data.ts
@@ -172,6 +172,7 @@ export const colors = {
   $text_secondary: '',
   $text_on_gradient: '',
   $text_accent: '',
+  $text_gradient: '',
 
   $metadata_secondary_label_color: '',
 

--- a/src/design-tokens/sx.css.ts
+++ b/src/design-tokens/sx.css.ts
@@ -105,6 +105,8 @@ const colorProperties = defineProperties({
     borderImageSource: vars.colors,
     backgroundImage: vars.colors,
     backgroundColor: vars.colors,
+    WebkitBackgroundClip: ['text'],
+    WebkitTextFillColor: ['transparent'],
   },
 });
 

--- a/src/design-tokens/theme/dark-theme.css.ts
+++ b/src/design-tokens/theme/dark-theme.css.ts
@@ -244,6 +244,7 @@ const colors: Colors = {
   $text_secondary: darkColorScheme.$primary_light_grey,
   $text_on_gradient: darkColorScheme.$primary_white,
   $text_accent: darkColorScheme.$primary_accent_purple,
+  $text_gradient: laceGradient,
 
   $metadata_secondary_label_color: darkColorScheme.$primary_light_grey,
 

--- a/src/design-tokens/theme/light-theme.css.ts
+++ b/src/design-tokens/theme/light-theme.css.ts
@@ -265,6 +265,7 @@ const colors: Colors = {
   $text_secondary: lightColorScheme.$primary_dark_grey,
   $text_on_gradient: lightColorScheme.$primary_white,
   $text_accent: lightColorScheme.$primary_accent_purple,
+  $text_gradient: laceGradient,
 
   $metadata_secondary_label_color: lightColorScheme.$primary_dark_grey,
 

--- a/src/icons/LockIconGradientComponent.tsx
+++ b/src/icons/LockIconGradientComponent.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import type { SVGProps } from 'react';
+const SvgLockIconGradientcomponent = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={29}
+    height={32}
+    fill="none"
+    {...props}
+  >
+    <path
+      stroke="url(#lock-icon-gradient_component_svg__a)"
+      strokeLinecap="round"
+      strokeWidth={2}
+      d="M7.833 14.333V7.667a6.667 6.667 0 1 1 13.334 0M14.5 21v3.333M4.5 31h20a3.333 3.333 0 0 0 3.333-3.333v-10a3.333 3.333 0 0 0-3.333-3.334h-20a3.333 3.333 0 0 0-3.333 3.334v10A3.333 3.333 0 0 0 4.5 31Z"
+    />
+    <defs>
+      <linearGradient
+        id="lock-icon-gradient_component_svg__a"
+        x1={-3.713}
+        x2={35.401}
+        y1={-4.489}
+        y2={-1.925}
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#FF92DE" />
+        <stop offset={1} stopColor="#FDC300" />
+      </linearGradient>
+    </defs>
+  </svg>
+);
+export default SvgLockIconGradientcomponent;

--- a/src/icons/PlusIconGradientComponent.tsx
+++ b/src/icons/PlusIconGradientComponent.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import type { SVGProps } from 'react';
+const SvgPlusIconGradientcomponent = (props: SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={29}
+    height={30}
+    fill="none"
+    {...props}
+  >
+    <path
+      stroke="url(#plus-icon-gradient_component_svg__a)"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M14.5 1.667v26.666M27.833 15H1.167"
+    />
+    <defs>
+      <linearGradient
+        id="plus-icon-gradient_component_svg__a"
+        x1={-3.713}
+        x2={35.357}
+        y1={-3.213}
+        y2={-0.331}
+        gradientUnits="userSpaceOnUse"
+      >
+        <stop stopColor="#FF92DE" />
+        <stop offset={1} stopColor="#FDC300" />
+      </linearGradient>
+    </defs>
+  </svg>
+);
+export default SvgPlusIconGradientcomponent;

--- a/src/icons/index.ts
+++ b/src/icons/index.ts
@@ -41,6 +41,7 @@ export { default as LightBulbGradientComponent } from './LightBulbGradientCompon
 export { default as LoaderDarkGradientComponent } from './LoaderDarkGradientComponent';
 export { default as LoaderLightGradientComponent } from './LoaderLightGradientComponent';
 export { default as LoadingComponent } from './LoadingComponent';
+export { default as LockIconGradientComponent } from './LockIconGradientComponent';
 export { default as MnemonicComponent } from './MnemonicComponent';
 export { default as NewspaperGradientComponent } from './NewspaperGradientComponent';
 export { default as PaperwalletComponent } from './PaperwalletComponent';
@@ -49,6 +50,7 @@ export { default as PencilOutlineComponent } from './PencilOutlineComponent';
 export { default as PlainCircleComponent } from './PlainCircleComponent';
 export { default as PlusCircleGradientComponent } from './PlusCircleGradientComponent';
 export { default as PlusCircleComponent } from './PlusCircleComponent';
+export { default as PlusIconGradientComponent } from './PlusIconGradientComponent';
 export { default as PlusSmallComponent } from './PlusSmallComponent';
 export { default as PrinterComponent } from './PrinterComponent';
 export { default as QrcodeComponent } from './QrcodeComponent';

--- a/src/icons/raw/lock-icon-gradient.component.svg
+++ b/src/icons/raw/lock-icon-gradient.component.svg
@@ -1,0 +1,9 @@
+<svg width="29" height="32" viewBox="0 0 29 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.83317 14.3333V7.66667C7.83317 3.98477 10.8179 1 14.4998 1C18.1817 1 21.1665 3.98477 21.1665 7.66667M14.4998 21V24.3333M4.49984 31H24.4998C26.3408 31 27.8332 29.5076 27.8332 27.6667V17.6667C27.8332 15.8257 26.3408 14.3333 24.4998 14.3333H4.49984C2.65889 14.3333 1.1665 15.8257 1.1665 17.6667V27.6667C1.1665 29.5076 2.65889 31 4.49984 31Z" stroke="url(#paint0_linear_7695_1225)" stroke-width="2" stroke-linecap="round"/>
+<defs>
+<linearGradient id="paint0_linear_7695_1225" x1="-3.71293" y1="-4.48935" x2="35.4013" y2="-1.925" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF92DE"/>
+<stop offset="1" stop-color="#FDC300"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/icons/raw/plus-icon-gradient.component.svg
+++ b/src/icons/raw/plus-icon-gradient.component.svg
@@ -1,0 +1,9 @@
+<svg width="29" height="30" viewBox="0 0 29 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.4998 1.66675V28.3334M27.8332 15.0001L1.1665 15.0001" stroke="url(#paint0_linear_7695_101)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<defs>
+<linearGradient id="paint0_linear_7695_101" x1="-3.71293" y1="-3.21268" x2="35.3569" y2="-0.331053" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF92DE"/>
+<stop offset="1" stop-color="#FDC300"/>
+</linearGradient>
+</defs>
+</svg>


### PR DESCRIPTION
This PR introduces new wallet onboarding options icons. Also, one new text colors is introduced: `laceGradient`.

Screenshots:

<img width="342" alt="Screenshot 2024-07-16 at 09 55 33" src="https://github.com/user-attachments/assets/ae8f55b2-7744-41df-b5d0-9b071f6b5df7">
