### PR TITLE
fix: center eye icon in password input component [LW-10644]

### DIFF
--- a/src/design-system/password-box/password-box-button.css.ts
+++ b/src/design-system/password-box/password-box-button.css.ts
@@ -10,7 +10,9 @@ export const inputButton = style([
     background: vars.colors.$input_button_bgColor,
     border: 'none',
     cursor: 'pointer',
-    flex: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
 
     ':disabled': {
       cursor: 'default',


### PR DESCRIPTION
This PR fixes an issue with the `<PasswordBox>` component required for https://input-output.atlassian.net/browse/LW-10644 where the "show/hide password" button icon is not correctly centered when used there:

<img width="592" alt="Bildschirmfoto 2024-07-23 um 12 54 56" src="https://github.com/user-attachments/assets/88cd0f06-1bfa-429f-b445-ad552a89ab0b">

I have no idea how it could have been correctly aligned before (in Storybook it looks correct) since there are no styles for centering it, so it seems it was probably coincidence that it worked so far.

This is how it looks after this fix:
![image](https://github.com/user-attachments/assets/1ef87208-c04a-46d8-a14e-39615380acc8)
