### PR TITLE
test: add test ids for PasswordBox [LW-10799]

### DIFF
--- a/src/design-system/password-box/password-box-button.component.tsx
+++ b/src/design-system/password-box/password-box-button.component.tsx
@@ -10,12 +10,14 @@ interface PasswordBoxButtonProps {
   onClick: (event: Readonly<React.MouseEvent<HTMLButtonElement>>) => void;
   disabled: boolean;
   isPasswordVisible: boolean;
+  testId?: string;
 }
 
 export const PasswordInputButton = ({
   onClick,
   disabled,
   isPasswordVisible,
+  testId,
 }: Readonly<PasswordBoxButtonProps>): JSX.Element => {
   return (
     <button
@@ -23,6 +25,7 @@ export const PasswordInputButton = ({
       className={cx.inputButton}
       onClick={onClick}
       disabled={disabled}
+      data-testid={testId}
     >
       {isPasswordVisible ? (
         <CloseEye

--- a/src/design-system/password-box/password-box-input.component.tsx
+++ b/src/design-system/password-box/password-box-input.component.tsx
@@ -21,6 +21,7 @@ export interface PasswordInputProps extends Form.FormControlProps {
   defaultIsPasswordVisible?: boolean;
   containerClassName?: string;
   containerStyle?: React.CSSProperties;
+  testId?: string;
 }
 
 export const PasswordInput = ({
@@ -35,6 +36,7 @@ export const PasswordInput = ({
   onChange,
   defaultIsPasswordVisible = false,
   containerStyle,
+  testId,
 }: Readonly<PasswordInputProps>): JSX.Element => {
   const [isPasswordVisible, setIsPasswordVisible] = useState(
     defaultIsPasswordVisible,
@@ -62,6 +64,7 @@ export const PasswordInput = ({
               value={value}
               onChange={onChange}
               id={id}
+              data-testid={testId}
             />
           </Form.Control>
           <Form.Label
@@ -70,6 +73,7 @@ export const PasswordInput = ({
             {label}
           </Form.Label>
           <PasswordInputButton
+            testId={testId && `${testId}-toggle`}
             onClick={(event): void => {
               event.preventDefault();
               setIsPasswordVisible(!isPasswordVisible);


### PR DESCRIPTION
This PR introduces the missing `testId` implementation for PasswordBox and its toggle button (preview).