### PR TITLE
fix: pass autoFocus prop to uncontrolled pw input element

### DIFF
--- a/src/design-system/password-box/uncontrolled-password-box-input.component.tsx
+++ b/src/design-system/password-box/uncontrolled-password-box-input.component.tsx
@@ -41,6 +41,7 @@ export const UncontrolledPasswordInput = ({
   errorMessage = '',
   containerClassName = '',
   onChange,
+  autoFocus,
   defaultIsPasswordVisible = false,
   containerStyle,
   testId,
@@ -68,6 +69,7 @@ export const UncontrolledPasswordInput = ({
               type={isPasswordVisible ? 'text' : 'password'}
               required={required}
               placeholder=""
+              autoFocus={autoFocus}
               className={cn(cx.input, { [cx.largeDots]: !isPasswordVisible })}
               disabled={disabled}
               name={name}


### PR DESCRIPTION
A unit test in `lace` was failing after replacing Password with this component. Tested it with this change.