### PR TITLE
fix: box component now has a new property testId what will be rendered in the data-testid prop

### DIFF
--- a/src/design-system/box/box.component.tsx
+++ b/src/design-system/box/box.component.tsx
@@ -25,7 +25,7 @@ export type BoxProps = Pick<
   | 'px'
   | 'py'
   | 'w'
-> & { className?: string; style?: CSSProperties };
+> & { className?: string; testId?: string; style?: CSSProperties };
 
 export type Props = PropsWithChildren<BoxProps> &
   HTMLAttributes<HTMLDivElement>;
@@ -51,12 +51,14 @@ export const Box = forwardRef<HTMLDivElement | null, Readonly<Props>>(
       px,
       py,
       w,
+      testId = 'box',
       ...props
     },
     ref,
   ): JSX.Element => (
     <div
       {...props}
+      data-testid={testId}
       className={classNames(
         sx({ h, m, mb, ml, mr, mt, mx, my, p, pb, pl, pr, pt, px, py, w }),
         className,


### PR DESCRIPTION
Box component doesnt render `data-testid` on its inner div. This PR adds a new property `testId` to the Box component.