### PR TITLE
test: add testId to the root of TokenProfile [LW-11764]

### DIFF
--- a/src/design-system/assets-table/assets-table-token-profile.component.tsx
+++ b/src/design-system/assets-table/assets-table-token-profile.component.tsx
@@ -21,7 +21,7 @@ export const TokenProfile = ({
   testId = 'token-profile',
 }: Readonly<Props>): JSX.Element => {
   return (
-    <div className={cx.container}>
+    <div className={cx.container} data-testid={testId}>
       <Grid columns="$fitContent" gutters="$0">
         <Cell>
           <Box mr="$24">


### PR DESCRIPTION
This PR adds a testId to the root component of TokenProfile to enable some common scenarios in E2E tests. Previously, test ids were assigned only to the child components/nodes like **ticker**, **name**, and **icon**.