### PR TITLE
ci: use conventional commits preset for commit-analyzer

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,12 @@
     "main"
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     "@semantic-release/npm",


### PR DESCRIPTION
commit-analyzer by default uses the angular preset, which do not follow the conventional commits specification. This commit changes the preset to conventionalcommits https://www.conventionalcommits.org/en/v1.0.0/