### PR TITLE
feat: make token amount details configurable [LW-11733]

### DIFF
--- a/src/design-system/assets-table/assets-table-token-amount.component.tsx
+++ b/src/design-system/assets-table/assets-table-token-amount.component.tsx
@@ -2,25 +2,32 @@ import React from 'react';
 
 import { Flex } from '../flex';
 import { Text } from '../text';
+import { FontWeights } from '../text/create-text.util';
 
 import * as cx from './assets-table-token-amount.css';
 
+import type { TypographyVariants } from '../text/text.css';
+
 interface Props {
   amount: string;
-  fiatPrice: string;
+  details: string;
+  detailsColor?: TypographyVariants['color'];
+  detailsWeight?: FontWeights;
 }
 
 export const TokenAmount = ({
   amount,
-  fiatPrice,
+  details,
+  detailsColor = 'secondary',
+  detailsWeight = '$regular',
 }: Readonly<Props>): JSX.Element => {
   return (
     <Flex flexDirection="column" alignItems="flex-end" className={cx.container}>
       <Text.Body.Large weight="$semibold" data-testid="token-amount">
         {amount}
       </Text.Body.Large>
-      <Text.Body.Normal color="secondary" weight="$semibold">
-        {fiatPrice}
+      <Text.Body.Normal color={detailsColor} weight={detailsWeight}>
+        {details}
       </Text.Body.Normal>
     </Flex>
   );

--- a/src/design-system/assets-table/assets-table.stories.tsx
+++ b/src/design-system/assets-table/assets-table.stories.tsx
@@ -53,7 +53,22 @@ const SimpleAssetInfo = ({ id }: Readonly<AssetInfoProps>): JSX.Element => (
       name="Token name"
       description="Subtitle"
     />
-    <TokenAmount amount="23,584.48" fiatPrice="24,568.54 USD" />
+    <TokenAmount amount="23,584.48" details="24,568.54 USD" />
+  </AssetsTable>
+);
+
+const PendingAssetInfo = ({ id }: Readonly<AssetInfoProps>): JSX.Element => (
+  <AssetsTable id={id}>
+    <TokenProfile
+      imageSrc={cardanoImage}
+      name="Token with pending amount"
+      description="description"
+    />
+    <TokenAmount
+      amount="21,584.48"
+      details="+ 5 pending"
+      detailsColor="success"
+    />
   </AssetsTable>
 );
 
@@ -72,7 +87,7 @@ const DetailedAssetInfo = ({
       priceChange="+3.21"
       priceTrend={priceTrend}
     />
-    <TokenAmount amount="23,584.48" fiatPrice="24,568.54 USD" />
+    <TokenAmount amount="23,584.48" details="24,568.54 USD" />
   </AssetsTable>
 );
 
@@ -124,6 +139,11 @@ export const Overview = (): JSX.Element => (
           <Variants.Row>
             <Variants.Cell>
               <DetailedAssetInfo />
+            </Variants.Cell>
+          </Variants.Row>
+          <Variants.Row>
+            <Variants.Cell>
+              <PendingAssetInfo />
             </Variants.Cell>
           </Variants.Row>
         </Variants.Table>
@@ -188,7 +208,7 @@ export const Controls: Controls = ({
               priceChange={priceChange}
               priceTrend={priceTrend}
             />
-            <TokenAmount amount={tokenAmount} fiatPrice={fiatPrice} />
+            <TokenAmount amount={tokenAmount} details={fiatPrice} />
           </AssetsTable>
         </Flex>
       </Section>

--- a/src/design-system/password-box/password-box.stories.tsx
+++ b/src/design-system/password-box/password-box.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import { action } from '@storybook/addon-actions';
 import type { Meta } from '@storybook/react';


### PR DESCRIPTION
This PR makes the `AssetTable.TokenAmount` details more configurable (previously this was hardcoded for `fiatPrice`) so that its possible to apply any text color:

![image](https://github.com/user-attachments/assets/da8af8d7-c98a-4367-80a1-ddd0248dd930)
