### PR TITLE
feat: support TokenAmount details tooltip [LW-11733]

### DIFF
--- a/src/design-system/assets-table/assets-table-token-amount.component.tsx
+++ b/src/design-system/assets-table/assets-table-token-amount.component.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Flex } from '../flex';
 import { Text } from '../text';
 import { FontWeights } from '../text/create-text.util';
+import { Tooltip } from '../tooltip';
 
 import * as cx from './assets-table-token-amount.css';
 
@@ -13,6 +14,7 @@ interface Props {
   details: string;
   detailsColor?: TypographyVariants['color'];
   detailsWeight?: FontWeights;
+  detailsTooltip?: string;
 }
 
 export const TokenAmount = ({
@@ -20,6 +22,7 @@ export const TokenAmount = ({
   details,
   detailsColor = 'secondary',
   detailsWeight = '$regular',
+  detailsTooltip,
 }: Readonly<Props>): JSX.Element => {
   return (
     <Flex flexDirection="column" alignItems="flex-end" className={cx.container}>
@@ -27,7 +30,11 @@ export const TokenAmount = ({
         {amount}
       </Text.Body.Large>
       <Text.Body.Normal color={detailsColor} weight={detailsWeight}>
-        {details}
+        {detailsTooltip ? (
+          <Tooltip label={detailsTooltip}>{details}</Tooltip>
+        ) : (
+          details
+        )}
       </Text.Body.Normal>
     </Flex>
   );

--- a/src/design-system/assets-table/assets-table.stories.tsx
+++ b/src/design-system/assets-table/assets-table.stories.tsx
@@ -68,6 +68,7 @@ const PendingAssetInfo = ({ id }: Readonly<AssetInfoProps>): JSX.Element => (
       amount="21,584.48"
       details="+ 5 pending"
       detailsColor="success"
+      detailsTooltip="Pending coins represent tokens that the wallet recognizes but are not yet finalized by the network. These coins are currently unspendable until confirmed."
     />
   </AssetsTable>
 );


### PR DESCRIPTION
This PR adds support for an optional `TokenAmount` details tooltip:

![image](https://github.com/user-attachments/assets/2411097b-87aa-487c-80bc-999835eab72b)
