### PR TITLE
fix: apply popup styles on smaller screens [LW-12311]

### DIFF
--- a/src/design-tokens/sx.css.ts
+++ b/src/design-tokens/sx.css.ts
@@ -4,7 +4,7 @@ import { vars } from './theme';
 
 const responsiveProperties = defineProperties({
   conditions: {
-    popupScreen: { '@media': 'screen and (min-width: 360px)' },
+    popupScreen: { '@media': 'screen and (min-width: 0px)' },
     minimumScreen: { '@media': 'screen and (min-width: 668px)' },
     xSmallScreen: { '@media': 'screen and (min-width: 1024px)' },
     smallScreen: { '@media': 'screen and (min-width: 1280px)' },


### PR DESCRIPTION
This PR ensures that the popup screen (smallest) styles are applied in all smallest screen sizes (not starting at 360px which breaks layouts on sizes below).

Here is one example of the dapp connector popup which was resized to smaller than 360px and the layout is not destroyed:
![image](https://github.com/user-attachments/assets/eaf58dde-1571-4fea-b2d8-73ba82a71362)
