### PR TITLE
fix: optional Tooltip props [LW-12407]

### DIFF
--- a/src/design-system/tooltip/tooltip-root.component.tsx
+++ b/src/design-system/tooltip/tooltip-root.component.tsx
@@ -6,14 +6,13 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import { TooltipContent } from './tooltip-content.component';
 import * as cx from './tooltip-root.css';
 
-export type Props = Pick<
-  Tooltip.PopperContentProps,
-  'align' | 'children' | 'side'
-> &
-  typeof Tooltip.Root & {
-    label: ReactNode | string;
-    zIndex?: number;
-  };
+export type Props = typeof Tooltip.Root & {
+  align?: Tooltip.PopperContentProps['align'];
+  children?: Tooltip.PopperContentProps['children'];
+  side?: Tooltip.PopperContentProps['side'];
+  label: ReactNode | string;
+  zIndex?: number;
+};
 
 export const Root = ({
   label,


### PR DESCRIPTION
This PR fixes too strict types for `Tooltip` due to using `Pick` which loses the optional quality for picked props.