### PR TITLE
fix: add missing DialogTitle in SideDrawer.Header

### DIFF
--- a/src/design-system/side-drawer/side-drawer-content-header.component.tsx
+++ b/src/design-system/side-drawer/side-drawer-content-header.component.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import { DialogTitle } from '@radix-ui/react-dialog';
+import { VisuallyHidden } from '@radix-ui/react-visually-hidden';
+
 import { Box } from '../box';
 import { Flex } from '../flex';
 import * as NavigationButtons from '../navigation-buttons';
@@ -32,6 +35,9 @@ export const Header = ({
         </Flex>
       )}
       <Flex justifyContent="center" w="$fill">
+        <VisuallyHidden>
+          <DialogTitle>{text}</DialogTitle>
+        </VisuallyHidden>
         <Text.Body.Large weight="$bold" data-testid="drawer-header-title">
           {text}
         </Text.Body.Large>


### PR DESCRIPTION
This PR removes annoying console.errors in Lace V2 and fixes one a11y aspect.

<img width="415" alt="image" src="https://github.com/user-attachments/assets/2466f548-0feb-4ab8-979c-159046d9c7ec" />
